### PR TITLE
HCNOVEO-78 Make Google PLay release published automatically

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ platform :android do
         track: "internal", # or alpha, beta, production
         aab: aab_path,
         json_key: "fastlane/play-store-api-key.json",
-        release_status: "draft",
+        release_status: "completed", # valid values are completed, draft, halted, inProgress
         skip_upload_metadata: true,
         skip_upload_images: true,
         skip_upload_screenshots: true,


### PR DESCRIPTION
## Related Issues
App:

- [ ] Add changelog files for the fixed issues in folder changelog/unreleased. More info [here](https://github.com/owncloud/android/tree/master/changelog#create-changelog-items)
- [ ] Add feature to Release Notes in `ReleaseNotesViewModel.kt` creating a new `ReleaseNote()` with String resources (if required)

_____

## QA
